### PR TITLE
Fix issue with rewound response bodies

### DIFF
--- a/src/PhpDebugBarMiddleware.php
+++ b/src/PhpDebugBarMiddleware.php
@@ -48,7 +48,11 @@ class PhpDebugBarMiddleware
         $debugBarBody = $this->debugBarRenderer->render();
 
         if ($this->isHtmlResponse($outResponse)) {
-            $outResponse->getBody()->write($debugBarHead . $debugBarBody);
+            $body = $outResponse->getBody();
+            if (! $body->eof() && $body->isSeekable()) {
+                $body->seek(0, SEEK_END);
+            }
+            $body->write($debugBarHead . $debugBarBody);
 
             return $outResponse;
         }

--- a/test/PhpDebugBarMiddlewareTest.php
+++ b/test/PhpDebugBarMiddlewareTest.php
@@ -80,4 +80,25 @@ class PhpDebugBarMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($response, $result);
         $this->assertSame("ResponseBodyRenderHeadRenderBody", (string) $result->getBody());
     }
+
+    public function testAppendsToEndOfHtmlResponse()
+    {
+        $html = '<html><head><title>Foo</title></head><body>Content</body>';
+        $request = new ServerRequest([], [], null, null, 'php://input', ['Accept' => 'text/html']);
+        $response = new Response\HtmlResponse($html);
+        $calledOut = false;
+        $outFunction = function ($request, $response) use (&$calledOut) {
+            $calledOut = true;
+            return $response;
+        };
+
+        $this->debugbarRenderer->expects($this->once())->method('renderHead')->willReturn('RenderHead');
+        $this->debugbarRenderer->expects($this->once())->method('render')->willReturn('RenderBody');
+
+        $result = call_user_func($this->middleware, $request, $response, $outFunction);
+
+        $this->assertTrue($calledOut, 'Out is not called');
+        $this->assertSame($response, $result);
+        $this->assertSame($html . 'RenderHeadRenderBody', (string) $result->getBody());
+    }
 }


### PR DESCRIPTION
When middleware returns an `HtmlResponse`, the body stream is typically rewound, with the pointer at position 0. Unfortunately, this means that any `write()` operations will *overwrite*!

This patch does a check to see if the response is at `eof()`, and, if not and the response is seekable, sets the pointer to the end of the stream prior to writing.