### PR TITLE
Autoload static files without copy/paste

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "zendframework/zend-diactoros": "^1.1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.6"
+        "phpunit/phpunit": "^4.8.6",
+        "mikey179/vfsStream": "^1.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/PhpDebugBarMiddleware.php
+++ b/src/PhpDebugBarMiddleware.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\UriInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Diactoros\Response\Serializer;
+use Zend\Diactoros\Stream;
 
 /**
  * PhpDebugBarMiddleware
@@ -90,9 +91,8 @@ class PhpDebugBarMiddleware
             return;
         }
 
-        $staticResponse = new Response();
-        $staticResponse->getBody()->write(file_get_contents($fullPathToFile));
-
+        $stream = new Stream($fullPathToFile, 'r');
+        $staticResponse = new Response($stream);
         $contentType = $this->getContentTypeByFileName($fullPathToFile);
 
         return $staticResponse->withHeader('Content-type', $contentType);

--- a/src/PhpDebugBarMiddleware.php
+++ b/src/PhpDebugBarMiddleware.php
@@ -107,12 +107,21 @@ class PhpDebugBarMiddleware
     {
         $ext = pathinfo($filename, PATHINFO_EXTENSION);
 
-        switch ($ext) {
-            case 'css':
-                return 'text/css';
-            case 'js':
-                return 'text/javascript';
+        $map = [
+            'css' => 'text/css',
+            'js' => 'text/javascript',
+            'otf' => 'font/opentype',
+            'eot' => 'application/vnd.ms-fontobject',
+            'svg' => 'image/svg+xml',
+            'ttf' => 'application/font-sfnt',
+            'woff' => 'application/font-woff',
+            'woff2' => 'application/font-woff2',
+        ];
+
+        if (isset($map[$ext])) {
+            return $map[$ext];
         }
+
         return 'text/plain';
     }
 

--- a/test/PhpDebugBarMiddlewareTest.php
+++ b/test/PhpDebugBarMiddlewareTest.php
@@ -3,16 +3,19 @@
 namespace PhpMiddlewareTest\PhpDebugBar;
 
 use DebugBar\JavascriptRenderer;
+use org\bovigo\vfs\vfsStream;
 use PhpMiddleware\PhpDebugBar\PhpDebugBarMiddleware;
+use PHPUnit_Framework_TestCase;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Uri;
 
 /**
  * PhpDebugBarMiddlewareTest
  *
  * @author Witold Wasiczko <witold@wasiczko.pl>
  */
-class PhpDebugBarMiddlewareTest extends \PHPUnit_Framework_TestCase
+class PhpDebugBarMiddlewareTest extends PHPUnit_Framework_TestCase
 {
     protected $debugbarRenderer;
     protected $middleware;
@@ -100,5 +103,62 @@ class PhpDebugBarMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($calledOut, 'Out is not called');
         $this->assertSame($response, $result);
         $this->assertSame($html . 'RenderHeadRenderBody', (string) $result->getBody());
+    }
+
+    public function testTryToHandleNotExistingStaticFile()
+    {
+        $this->debugbarRenderer->expects($this->any())->method('getBaseUrl')->willReturn('/phpdebugbar');
+
+        $uri = new Uri('http://example.com/phpdebugbar/boo.css');
+        $request = new ServerRequest([], [], $uri, null, 'php://memory');
+        $response = new Response\HtmlResponse('<html></html>');
+
+        $calledOut = false;
+        $outFunction = function ($request, $response) use (&$calledOut) {
+            $calledOut = true;
+            return $response;
+        };
+
+        $result = call_user_func($this->middleware, $request, $response, $outFunction);
+        $this->assertTrue($calledOut, 'Out is not called');
+        $this->assertSame($response, $result);
+    }
+
+    /**
+     * @dataProvider getContentTypes
+     */
+    public function testHandleStaticFile($extension, $contentType)
+    {
+        $root = vfsStream::setup('boo');
+
+        $this->debugbarRenderer->expects($this->any())->method('getBaseUrl')->willReturn('/phpdebugbar');
+        $this->debugbarRenderer->expects($this->any())->method('getBasePath')->willReturn(vfsStream::url('boo'));
+
+        $uri = new Uri(sprintf('http://example.com/phpdebugbar/debugbar.%s', $extension));
+        $request = new ServerRequest([], [], $uri, null, 'php://memory');
+        $response = new Response\HtmlResponse('<html></html>');
+
+        vfsStream::newFile(sprintf('debugbar.%s', $extension))->withContent('filecontent')->at($root);
+
+        $calledOut = false;
+        $outFunction = function ($request, $response) use (&$calledOut) {
+            $calledOut = true;
+            return $response;
+        };
+
+        $result = call_user_func($this->middleware, $request, $response, $outFunction);
+        $this->assertFalse($calledOut, 'Out is called');
+        $this->assertNotSame($response, $result);
+        $this->assertSame($contentType, $result->getHeaderLine('Content-type'));
+        $this->assertSame('filecontent', (string) $result->getBody());
+    }
+
+    public function getContentTypes()
+    {
+        return [
+            ['css', 'text/css'],
+            ['js', 'text/javascript'],
+            ['html', 'text/plain'],
+        ];
     }
 }


### PR DESCRIPTION
This pr make installation simple as possible and make middleware ready to use out-of-box. Solution for #2 