### PR TITLE
Zend Expressive

### DIFF
--- a/src/DataCollector/PDO/ZendDbCollector.php
+++ b/src/DataCollector/PDO/ZendDbCollector.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpMiddleware\PhpDebugBar\DataCollector\PDO;
+
+use DebugBar\DataCollector\PDO\PDOCollector;
+
+class ZendDbCollector extends PDOCollector
+{
+
+}

--- a/src/DataCollector/PDO/ZendDbCollectorFactory.php
+++ b/src/DataCollector/PDO/ZendDbCollectorFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PhpMiddleware\PhpDebugBar\DataCollector\PDO;
+
+use Interop\Container\ContainerInterface;
+use DebugBar\DataCollector\PDO\TraceablePDO;
+use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\Adapter\Driver\Pdo\Pdo;
+use PhpMiddleware\PhpDebugBar\Exception;
+
+class ZendDbCollectorFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        if (! $container->has(AdapterInterface::class)) {
+            throw new Exception\MissingServiceException(sprintf(
+                '%s requires a %s service at instantiation; none found', 
+                ZendDbCollectorFactory::class, 
+                AdapterInterface::class
+            ));
+        }
+        $dbAdapter = $container->get(AdapterInterface::class);
+        $driver = $dbAdapter->getDriver();
+        
+        if (! $driver instanceof Pdo) {
+            throw new Exception\RuntimeException(sprintf(
+                'Driver must be instance of %s', 
+                Pdo::class
+            ));
+        }
+        
+        $pdo = $driver->getConnection()->getResource();
+        $traceablePdo = new TraceablePDO($pdo);
+        $pdoCollector = new ZendDbCollector($traceablePdo);
+
+        return $pdoCollector;
+    }
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpMiddleware\PhpDebugBar\Exception;
+
+interface ExceptionInterface
+{
+}

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PhpMiddleware\PhpDebugBar\Exception;
+
+use DomainException;
+use Interop\Container\Exception\ContainerException;
+
+class InvalidConfigException extends DomainException implements
+    ContainerException,
+    ExceptionInterface
+{
+}

--- a/src/Exception/MissingServiceException.php
+++ b/src/Exception/MissingServiceException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PhpMiddleware\PhpDebugBar\Exception;
+
+class MissingServiceException extends RuntimeException implements
+    ExceptionInterface
+{
+}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PhpMiddleware\PhpDebugBar\Exception;
+
+class RuntimeException extends \RuntimeException implements
+    ExceptionInterface
+{
+}

--- a/src/PhpDebugBarMiddlewareFactory.php
+++ b/src/PhpDebugBarMiddlewareFactory.php
@@ -4,14 +4,9 @@ namespace PhpMiddleware\PhpDebugBar;
 
 use Interop\Container\ContainerInterface;
 use ArrayObject;
-use DebugBar\DebugBar;
 use DebugBar\StandardDebugBar;
 use DebugBar\JavascriptRenderer;
 use DebugBar\DataCollector\ConfigCollector;
-use DebugBar\DataCollector\PDO\TraceablePDO;
-use DebugBar\DataCollector\PDO\PDOCollector;
-use Zend\Db\Adapter\AdapterInterface;
-use Zend\Db\Adapter\Driver\Pdo\Pdo;
 use PhpMiddleware\PhpDebugBar\PhpDebugBarMiddleware;
 
 /**
@@ -61,12 +56,6 @@ class PhpDebugBarMiddlewareFactory
         // Config Collectors
         $debugBar->addCollector(new ConfigCollector($config));
         
-        // Db profiler
-        if ($container->has(AdapterInterface::class) && isset($config['db']['driver'])) {
-            $dbAdapter = $container->get(AdapterInterface::class);
-            $this->prepareDbCollector($dbAdapter, $debugBar);
-        }
-        
         // Collectors
         $collectors = (isset($debugBarConfig['collectors']) && is_array($debugBarConfig['collectors']))
             ? $debugBarConfig['collectors']
@@ -87,22 +76,5 @@ class PhpDebugBarMiddlewareFactory
         $javascriptRenderer->setOptions($debugBarOptions);
 
         return new PhpDebugBarMiddleware($javascriptRenderer);
-    }
-    
-    /**
-     * Prepare database collector
-     * 
-     * @param AdapterInterface $adapter
-     * @param DebugBar $debugbar
-     */
-    protected function prepareDbCollector(AdapterInterface $adapter, DebugBar $debugbar)
-    {
-        $driver = $adapter->getDriver();
-        if ($driver instanceof Pdo) {
-            $pdo = $driver->getConnection()->getResource();
-            $traceablePdo = new TraceablePDO($pdo);
-            $pdoCollector = new PDOCollector($traceablePdo);
-            $debugbar->addCollector($pdoCollector);
-        }
     }
 }

--- a/src/PhpDebugBarMiddlewareFactory.php
+++ b/src/PhpDebugBarMiddlewareFactory.php
@@ -2,20 +2,107 @@
 
 namespace PhpMiddleware\PhpDebugBar;
 
+use Interop\Container\ContainerInterface;
+use ArrayObject;
+use DebugBar\DebugBar;
 use DebugBar\StandardDebugBar;
+use DebugBar\JavascriptRenderer;
+use DebugBar\DataCollector\ConfigCollector;
+use DebugBar\DataCollector\PDO\TraceablePDO;
+use DebugBar\DataCollector\PDO\PDOCollector;
+use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\Adapter\Driver\Pdo\Pdo;
+use PhpMiddleware\PhpDebugBar\PhpDebugBarMiddleware;
 
 /**
- * Default, simple factory for middleware
- *
- * @author Witold Wasiczko <witold@wasiczko.pl>
+ * Create and return a DebugBar instance
+ * 
+ * Optionally uses the service 'config', which should return an array. This
+ * factory consumes the following structure:
+ * 
+ * <code>
+ * 'phpdebugbar' => [
+ *     // set default options, 
+ *     // @see JavascriptRenderer::setOptions()
+ *     'options' => []
+ *     // additional collectors
+ *     'collectors' => [],
+ *     // storage
+ *     'storage' => null,
+ * ],
+ * </code>
  */
 class PhpDebugBarMiddlewareFactory
 {
-    public function __invoke()
+    public function __invoke(ContainerInterface $container)
     {
-        $debugbar = new StandardDebugBar();
-        $renderer = $debugbar->getJavascriptRenderer('/phpdebugbar');
+        $config = $container->has('config') ? $container->get('config') : [];
+        
+        if (! is_array($config) && ! $config instanceof ArrayObject) {
+            throw new Exception\InvalidConfigException(sprintf(
+                '"config" service must be an array or ArrayObject for the %s to be able to consume it; received %s',
+                __CLASS__,
+                (is_object($config) ? get_class($config) : gettype($config))
+            ));
+        }
+        
+        $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
+        
+        $debugBarConfig = (isset($config['phpdebugbar']) && is_array($config['phpdebugbar']))
+            ? $config['phpdebugbar']
+            : [];
+        
+        $debugBarOptions = (isset($debugBarConfig['options']) && is_array($debugBarConfig['options']))
+            ? $debugBarConfig['options']
+            : [];
+        
+        $debugBar = new StandardDebugBar();
+        
+        // Config Collectors
+        $debugBar->addCollector(new ConfigCollector($config));
+        
+        // Db profiler
+        if ($container->has(AdapterInterface::class) && isset($config['db']['driver'])) {
+            $dbAdapter = $container->get(AdapterInterface::class);
+            $this->prepareDbCollector($dbAdapter, $debugBar);
+        }
+        
+        // Collectors
+        $collectors = (isset($debugBarConfig['collectors']) && is_array($debugBarConfig['collectors']))
+            ? $debugBarConfig['collectors']
+            : [];
+        
+        foreach ($collectors as $collectorName) {
+            $collector = $container->get($collectorName);
+            $debugBar->addCollector($collector);
+        }
+        
+        // Storage
+        if (isset($debugBarConfig['storage']) && $container->has($debugBarConfig['storage'])) {
+            $storage = $container->get($debugBarConfig['storage']);
+            $debugBar->setStorage($storage);
+        }
+        
+        $javascriptRenderer = new JavascriptRenderer($debugBar);
+        $javascriptRenderer->setOptions($debugBarOptions);
 
-        return new PhpDebugBarMiddleware($renderer);
+        return new PhpDebugBarMiddleware($javascriptRenderer);
+    }
+    
+    /**
+     * Prepare database collector
+     * 
+     * @param AdapterInterface $adapter
+     * @param DebugBar $debugbar
+     */
+    protected function prepareDbCollector(AdapterInterface $adapter, DebugBar $debugbar)
+    {
+        $driver = $adapter->getDriver();
+        if ($driver instanceof Pdo) {
+            $pdo = $driver->getConnection()->getResource();
+            $traceablePdo = new TraceablePDO($pdo);
+            $pdoCollector = new PDOCollector($traceablePdo);
+            $debugbar->addCollector($pdoCollector);
+        }
     }
 }


### PR DESCRIPTION
This branch is created to work only with Zend Expressive. 
Factory adds new Config and Database collectors.
External config file is consumed with the following structure:

**phpdebugbar.local.php**

``` php
<?php

return [
    'phpdebugbar' => [
        'options' => [
            'base_url' => '/phpdebugbar',
        ],
        'collectors' => [],
        'storage' => null,
    ],
];
```
