### PR TITLE
Exclude by default content-types !== 'text/html'

### DIFF
--- a/src/PhpDebugBarMiddleware.php
+++ b/src/PhpDebugBarMiddleware.php
@@ -25,11 +25,25 @@ class PhpDebugBarMiddleware implements MiddlewareInterface
 {
     use DoublePassCompatibilityTrait;
 
+    /**
+     * @var DebugBarRenderer
+     */
     protected $debugBarRenderer;
 
-    public function __construct(DebugBarRenderer $debugbarRenderer)
+    /**
+     * @var bool
+     */
+    protected $excludeNonHtmlContent;
+
+    /**
+     * PhpDebugBarMiddleware constructor.
+     * @param DebugBarRenderer $debugbarRenderer
+     * @param bool $excludeNonHtmlContent Whether to disable debugbar on content-types != 'test/html'
+     */
+    public function __construct(DebugBarRenderer $debugbarRenderer, $excludeNonHtmlContent=true)
     {
         $this->debugBarRenderer = $debugbarRenderer;
+        $this->excludeNonHtmlContent = $excludeNonHtmlContent;
     }
 
     /**
@@ -49,7 +63,10 @@ class PhpDebugBarMiddleware implements MiddlewareInterface
 
         if ($this->isHtmlResponse($response)) {
             return $this->attachDebugBarToResponse($response);
+        } elseif ($this->excludeNonHtmlContent) {
+            return $response;
         }
+
         return $this->prepareHtmlResponseWithDebugBar($response);
     }
 

--- a/src/PhpDebugBarMiddleware.php
+++ b/src/PhpDebugBarMiddleware.php
@@ -36,11 +36,10 @@ class PhpDebugBarMiddleware implements MiddlewareInterface
     protected $excludeNonHtmlContent;
 
     /**
-     * PhpDebugBarMiddleware constructor.
      * @param DebugBarRenderer $debugbarRenderer
      * @param bool $excludeNonHtmlContent Whether to disable debugbar on content-types != 'test/html'
      */
-    public function __construct(DebugBarRenderer $debugbarRenderer, $excludeNonHtmlContent=true)
+    public function __construct(DebugBarRenderer $debugbarRenderer, $excludeNonHtmlContent=false)
     {
         $this->debugBarRenderer = $debugbarRenderer;
         $this->excludeNonHtmlContent = $excludeNonHtmlContent;


### PR DESCRIPTION
see https://github.com/php-middleware/phpdebugbar/issues/18